### PR TITLE
Fixes Content Overflow Issue

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,18 +7,18 @@
 </template>
 
 <script>
-export default {
-  name: "App",
-  components: {},
-  data: () => ({}),
-};
+  export default {
+    name: "App",
+    components: {},
+    data: () => ({}),
+  };
 </script>
 
 <style>
   .appGrid {
     display: grid;
-    grid-template-columns: auto;
-    grid-template-rows: auto;
+    grid-template-columns: minmax(auto, 1fr);
+    grid-template-rows: minmax(auto, 1fr);
     grid-template-areas: "mainSlot";
   }
 

--- a/src/components/StudentHomeDashboard.vue
+++ b/src/components/StudentHomeDashboard.vue
@@ -93,15 +93,15 @@
   .studentHomeMainGrid {
     display: grid;
     grid-template-columns: 3fr 2fr;
-    grid-template-rows: auto;
+    grid-template-rows: minmax(auto, 1fr);
     grid-template-areas: "eventsRepPane critiquesPane";
     grid-gap: 1.5rem;
     padding-left: 0;
   }
   .studentHomeLeftGrid {
     display: grid;
-    grid-template-columns: auto;
-    grid-template-rows: 1fr 1fr;
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(auto, 1fr), minmax(auto, 1fr);
     grid-template-areas:
       "eventsPane"
       "repertoirePane";

--- a/src/views/BaseDashboard.vue
+++ b/src/views/BaseDashboard.vue
@@ -22,7 +22,7 @@
     /* padding: 15px !important; */
     display: grid;
     grid-template-columns: 0.5fr 2fr 8fr;
-    grid-template-rows: 1fr;
+    grid-template-rows: minmax(auto, 1fr);
     grid-template-areas: "menuBarPane userSidebarPane dashboardSlot";
     grid-gap: 1.5rem;
   }


### PR DESCRIPTION
Content was overflowing it's container on the dashboard, resolved that issue.

Had to add `minmax(auto, _fr)` to and rows that were previously just `auto`. This makes them auto size only up to a max of whatever `fr` unit applies to them.