### PR TITLE
Update Events Page to Use Real Data

### DIFF
--- a/src/components/EventSignupItem.vue
+++ b/src/components/EventSignupItem.vue
@@ -10,7 +10,7 @@
             {{ eventData.date }}
           </v-card-subtitle>
           <v-card-subtitle class="font-weight-semi-bold text-darkBlue pl-0">
-            {{ createTimesInfoString() }}
+            {{ timesInfoString }}
           </v-card-subtitle>
           <v-card-subtitle class="font-weight-medium text-mediumBlue pl-0">
             {{ eventData.location }}
@@ -59,6 +59,8 @@
 
 <script>
   import EventItem from "./EventItem.vue";
+  import { useEventsStore } from "../stores/EventsStore.js";
+  import { mapStores } from "pinia";
   export default {
     name: "EventSignupItem",
     components: {
@@ -68,25 +70,34 @@
       return {
         signUpDialog: false,
         eventData: {
-          type: "Vocal Jury",
-          date: "04/22/2023",
-          times: [
-            { startTime: "9:00am", endTime: "12:00pm" },
-            { startTime: "1:00pm", endTime: "3:00pm" },
-          ],
+          type: "",
+          date: "",
+          times: [],
           location: "Adams Recital Hall",
           timeslots: { total: 25, filled: 14 },
         },
+        timesInfoString: "",
       };
+    },
+    computed: {
+      ...mapStores(useEventsStore),
+    },
+    mounted() {
+      this.retrieveInfo();
+    },
+    props: {
+      eventId: 1,
     },
     methods: {
       createTimesInfoString() {
         let timesString = "";
         for (let i = 0; i < this.eventData.times.length; i++) {
           timesString +=
-            this.eventData.times[i].startTime +
+            this.get12HourTimeString(
+              new Date(this.eventData.times[i].startTime)
+            ) +
             " - " +
-            this.eventData.times[i].endTime;
+            this.get12HourTimeString(new Date(this.eventData.times[i].endTime));
           if (i + 1 < this.eventData.times.length) {
             timesString += " & ";
           }
@@ -94,8 +105,26 @@
 
         return timesString;
       },
+      get12HourTimeString(t) {
+        let hours = t.getHours();
+        let suffix = hours >= 12 ? "PM" : "AM";
+        hours = ((hours + 11) % 12) + 1;
+        let minutes = t.getMinutes() === 0 ? "00" : t.getMinutes();
+        return hours + ":" + minutes + suffix;
+      },
+      formatDate(date) {
+        const options = { year: "numeric", month: "numeric", day: "numeric" };
+        return new Date(date).toLocaleDateString("us-EN", options);
+      },
       closeEventDialog(val) {
         this.signUpDialog = val;
+      },
+      retrieveInfo() {
+        const event = this.eventsStore.getEventForId(this.eventId);
+        this.eventData.type = event.type;
+        this.eventData.date = this.formatDate(event.date);
+        this.eventData.times = event.times;
+        this.timesInfoString = this.createTimesInfoString();
       },
     },
   };

--- a/src/components/EventsDashboard.vue
+++ b/src/components/EventsDashboard.vue
@@ -4,9 +4,9 @@
       <v-card-title class="font-weight-bold text-h5 text-darkBlue">
         Open Event Signups
       </v-card-title>
-      <v-card-text>
+      <v-card-text v-for="id in openEventIds">
         <v-row>
-          <EventSignupItem />
+          <EventSignupItem :eventId="id" />
         </v-row>
       </v-card-text>
     </v-card>
@@ -14,9 +14,9 @@
       <v-card-title class="font-weight-bold text-darkBlue text-h5">
         Upcoming Events
       </v-card-title>
-      <v-card-text>
+      <v-card-text v-for="event in this.eventsStore.events">
         <v-row>
-          <EventUpcomingItem />
+          <EventUpcomingItem :eventId="event.id" />
         </v-row>
       </v-card-text>
     </v-card>
@@ -55,6 +55,8 @@
   import { useLoginStore } from "../stores/LoginStore.js";
   import { useEventsStore } from "../stores/EventsStore.js";
   import { mapStores } from "pinia";
+  import EventDataService from "../services/event.js";
+
   export default {
     name: "EventsDashboard",
     components: {
@@ -65,26 +67,45 @@
     data() {
       return {
         createDialog: false,
-        openEventSignups: [
-          {
-            eventType: "Vocal Jury",
-            eventDate: "04/22/2023",
-            eventTimes: [
-              { startTime: "9:00AM", endTime: "12:00PM" },
-              { startTime: "1:00pm", endTime: "3:00PM" },
-            ],
-            eventLocation: "Adams Recital Hall",
-            eventTimeslots: { total: 25, filled: 14 },
-          },
-        ],
+        openEventIds: [],
+        upcomingEventIds: [],
       };
     },
     computed: {
       ...mapStores(useLoginStore, useEventsStore),
     },
+    mounted() {
+      this.setEventsStore();
+      this.generateOpenEventIds();
+    },
     methods: {
       closeCreateDialog(val) {
         this.createDialog = val;
+      },
+      setEventsStore() {
+        EventDataService.getAll()
+          .then((response) => {
+            this.eventsStore.setEvents(response.data.Event);
+          })
+          .catch((e) => {
+            console.log(e);
+          });
+      },
+      generateOpenEventIds() {
+        let ids = [];
+        for (let event in this.eventsStore.events) {
+          ids.push(this.eventsStore.events[event].id);
+        }
+        console.log(ids);
+        this.openEventIds = ids;
+      },
+      generateUpcomingEventIds() {
+        let ids = [];
+        for (let event in this.eventsStore.events) {
+          ids.push(this.eventsStore.events[event].id);
+        }
+        console.log(ids);
+        this.upcomingEventIds = ids;
       },
     },
   };


### PR DESCRIPTION
This is going to be a bit confusing to explain.

General Flow:

- On EventsDashboard load - call to the backend and load events into EventsStore, with setEvents()
- setEvents() parses the data. Particularly date into a JS Date, times to a times object with startTime and endTime that are JS Date objects, along with id and title
- Then the EventsDashboard conditionally loads EventsSignupItems and EventsUpcomingItems based on their date (this isn't true to how it will work rn, but it's good enough for demo)
- Each EventsSignupItem (or EventsUpcomingItem) then queries the EventsStore based on the id they are given by the EventsDashboard and loads the data
- createTimesInfoString() creates the string of times that is displayed on the card
- get12HourTimeString() turns the time from 24hr time to 12hr time and adds the appropriate suffix
- formatDate() turns the date from yyyy-mm-dd to mm-dd-yyyy

It's a lot, but works really well it seems. I'll need to add more to get us actual data for a signup but this is done enough for our demo today.