### PR TITLE
Fix Events Page for Non-Students

### DIFF
--- a/src/components/Events/EventSignupItem.vue
+++ b/src/components/Events/EventSignupItem.vue
@@ -38,9 +38,19 @@
                 rounded="pill"
                 class="buttonGradient text-white font-weight-bold text-capitalize"
                 @click="
-                  hasPriorSignup ? (editDialog = true) : (signUpDialog = true)
+                  this.userStore.userInfo.role === 'student'
+                    ? hasPriorSignup
+                      ? (editDialog = true)
+                      : (signUpDialog = true)
+                    : (availabilityDialog = true)
                 ">
-                {{ hasPriorSignup ? "Edit" : "Signup" }}
+                {{
+                  this.userStore.userInfo.role === "student"
+                    ? hasPriorSignup
+                      ? "Edit"
+                      : "Signup"
+                    : "Add Availability"
+                }}
               </v-btn>
               <v-dialog v-model="signUpDialog" persistent max-width="1000px">
                 <EventItem
@@ -73,6 +83,8 @@
       return {
         signUpDialog: false,
         hasPriorSignup: false,
+        // Needs to be implemented
+        availabilityDialog: false,
         timesInfoString: "",
       };
     },

--- a/src/stores/EventsStore.js
+++ b/src/stores/EventsStore.js
@@ -148,11 +148,15 @@ export const useEventsStore = defineStore("events", {
       let eventSignups = new Array();
 
       for (let event of this.events) {
-        eventSignups = eventSignups.concat(
-          event.signups.filter(
-            (s) => s.studentinfoId === userStore.userRoleInfo.id
-          )
-        );
+        // We need to add support for faculty and admin once we update the database design
+        // TODO @ethanimooney: add this
+        if (userStore.userInfo.role === "student") {
+          eventSignups = eventSignups.concat(
+            event.signups.filter(
+              (s) => s.studentinfoId === userStore.userRoleInfo.id
+            )
+          );
+        }
       }
 
       return eventSignups;


### PR DESCRIPTION
Fixes bug where events page would lock user if they were not a student.

Added check in generateEventSignupsForUser for the user's role, need to add support for faculty and admin once we update the database to support adding availability and critiques for events.

Added check on EventSignupItem to make button change to 'Add Availability' for non-students.