### PR TITLE
Update Frontend for Role System pt 2

### DIFF
--- a/src/components/Events/EventSignupItem.vue
+++ b/src/components/Events/EventSignupItem.vue
@@ -36,14 +36,14 @@
                 rounded="pill"
                 class="buttonGradient text-white font-weight-bold text-capitalize"
                 @click="
-                  this.userStore.userInfo.roles[0].roleId === 1
+                  this.userStore.userInfo.roles.default.roleId === 1
                     ? hasPriorSignup
                       ? (editDialog = true)
                       : (signUpDialog = true)
                     : (availabilityDialog = true)
                 ">
                 {{
-                  this.userStore.userInfo.roles[0].roleId === 1
+                  this.userStore.userInfo.roles.default.roleId === 1
                     ? hasPriorSignup
                       ? "Edit"
                       : "Signup"

--- a/src/components/Student/StudentHomeDashboard.vue
+++ b/src/components/Student/StudentHomeDashboard.vue
@@ -33,7 +33,7 @@
               cols="6"
               :sm="12"
               :md="12"
-              :lg="12"
+              :lg="6"
               :xl="6"
               v-for="event in eventSignups">
               <EventComponent :eventSignUpData="event" />

--- a/src/components/UserSidebar.vue
+++ b/src/components/UserSidebar.vue
@@ -13,11 +13,11 @@
         {{ userTitleOrMajor }}
       </v-card-subtitle>
       <v-card-subtitle
-        v-if="userRole === 'student'"
+        v-if="isStudent"
         class="font-weight-medium text-mediumBlue">
         {{ userClassification }}
       </v-card-subtitle>
-      <v-card-text v-if="userRole === 'student'">
+      <v-card-text v-if="isStudent">
         <v-row>
           <v-col cols="12">
             <v-card-subtitle class="text-darkBlue pl-0">
@@ -74,9 +74,11 @@
     components: { NotificationItem },
     data() {
       return {
+        isStudent: false,
+        isFaculty: false,
         userId: 2,
         userPicture: "",
-        userRole: "",
+        userRoles: [],
         userName: "John Doe",
         userTitleOrMajor: "",
         userClassification: "Senior",
@@ -95,11 +97,12 @@
     },
     methods: {
       retrieveInfo() {
-        this.userRole = this.userStore.userInfo.role;
+        this.userRoles = this.userStore.userInfo.roles;
         this.userName = this.userStore.getFullName;
         this.userPicture = this.userStore.userInfo.picture;
 
-        if (this.userRole === "student") {
+        if (this.userRoles[0].roleId === 1) {
+          this.isStudent = true;
           this.userTitleOrMajor = this.userStore.userRoleInfo.major;
           this.useClassification = this.userStore.userRoleInfo.classification;
           this.userSemesters = this.userStore.userRoleInfo.semesters;
@@ -108,7 +111,8 @@
           console.log(this.userInstructor);
           this.setUserLevelPercent(this.userLevel);
           this.setSemestersPercent(this.userSemesters);
-        } else if (this.userRole === "faculty") {
+        } else if (this.userRoles[0].roleId === 2) {
+          this.isFaculty = true;
           this.userTitleOrMajor = this.userStore.userRoleInfo.title;
         }
       },

--- a/src/components/UserSidebar.vue
+++ b/src/components/UserSidebar.vue
@@ -78,7 +78,7 @@
         isFaculty: false,
         userId: 2,
         userPicture: "",
-        userRoles: [],
+        userDefaultRole: {},
         userName: "John Doe",
         userTitleOrMajor: "",
         userClassification: "Senior",
@@ -97,11 +97,11 @@
     },
     methods: {
       retrieveInfo() {
-        this.userRoles = this.userStore.userInfo.roles;
+        this.userDefaultRole = this.userStore.userInfo.roles.default;
         this.userName = this.userStore.getFullName;
         this.userPicture = this.userStore.userInfo.picture;
 
-        if (this.userRoles[0].roleId === 1) {
+        if (this.userDefaultRole.roleId === 1) {
           this.isStudent = true;
           this.userTitleOrMajor = this.userStore.userRoleInfo.major;
           this.useClassification = this.userStore.userRoleInfo.classification;
@@ -111,7 +111,7 @@
           console.log(this.userInstructor);
           this.setUserLevelPercent(this.userLevel);
           this.setSemestersPercent(this.userSemesters);
-        } else if (this.userRoles[0].roleId === 2) {
+        } else if (this.userDefaultRole.roleId === 2) {
           this.isFaculty = true;
           this.userTitleOrMajor = this.userStore.userRoleInfo.title;
         }

--- a/src/stores/EventsStore.js
+++ b/src/stores/EventsStore.js
@@ -150,7 +150,7 @@ export const useEventsStore = defineStore("events", {
       for (let event of this.events) {
         // We need to add support for faculty and admin once we update the database design
         // TODO @ethanimooney: add this
-        if (userStore.userInfo.roles[0].roleId === 1) {
+        if (userStore.userInfo.roles.default.roleId === 1) {
           eventSignups = eventSignups.concat(
             event.signups.filter(
               (s) => s.studentinfoId === userStore.userRoleInfo.id

--- a/src/stores/UserStore.js
+++ b/src/stores/UserStore.js
@@ -21,6 +21,14 @@ export const useUserStore = defineStore("user", {
     // Set the login user, and load their specific role info
     async setUser(user) {
       this.userInfo = user;
+      let roles = {
+        default: this.userInfo.roles[0],
+        additional: this.userInfo.roles.shift(),
+      };
+
+      delete this.userInfo.roles;
+      this.userInfo.roles = roles;
+
       await this.setUserRoleInfo();
     },
     // Clear the login user info, logging them out
@@ -30,13 +38,13 @@ export const useUserStore = defineStore("user", {
     },
     // Set the userRoleInfo based on the users role
     async setUserRoleInfo() {
-      let roles = this.userInfo.roles;
+      let defaultRole = this.userInfo.roles.default;
 
-      if (roles[0].roleId === 1) {
+      if (defaultRole.roleId === 1) {
         await this.setStudentRoleInfo();
-      } else if (roles[0].roleId === 2) {
+      } else if (defaultRole.roleId === 2) {
         await this.setFacultyRoleInfo();
-      } else if (roles[0].roleId === 3) {
+      } else if (defaultRole.roleId === 3) {
       }
     },
     async setStudentRoleInfo() {

--- a/src/views/BaseDashboard.vue
+++ b/src/views/BaseDashboard.vue
@@ -48,7 +48,7 @@
     },
     data() {
       return {
-        userRole: "",
+        userDefaultRole: "",
         userDashboard: "",
       };
     },
@@ -61,14 +61,14 @@
     },
     methods: {
       async retrieveInfo() {
-        this.userRole = this.userStore.userInfo.roles[0].roleId;
+        this.userDefaultRole = this.userStore.userInfo.roles.default;
       },
       setUserDashboard() {
-        if (this.userRole === 1) {
+        if (this.userDefaultRole.roleId === 1) {
           this.userDashboard = "StudentDashboard";
-        } else if (this.userRole === 2) {
+        } else if (this.userDefaultRole.roleId === 2) {
           this.userDashboard = "FacultyDashboard";
-        } else if (this.userRole === 3) {
+        } else if (this.userDefaultRole.roleId === 3) {
           this.userDashboard = "AdminDashboard";
         }
       },


### PR DESCRIPTION
Updates the frontend for the new roles system again.

this.userStore.userInfo.roles is now an object. Example:

{
default: {id: 1, roleId: 1, userId: 1},
additional: [],
}

The default role is the first role returned back by the backend, the additional roles are the rest. This should handle all normal 1 role users fine, and for the few that are faculty and admin, they will always be a faculty first and then get admin role after, so it works too. If we want, later on we can add checks to make the admin role default, but this works for now.