### PR TITLE
Instructor Add Availability and Student Signup Filter by Instructor Availability

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -77,7 +77,7 @@
   ) !important;
 }
 
-.selectedSong {
+.selectedListItem {
   /* box-shadow: 8px 10px 34px rgba(63, 134, 197, 0.4) !important; */
   background: linear-gradient(
     101.14deg,
@@ -86,7 +86,7 @@
   ) !important;
 }
 
-.unSelectedSong {
+.unSelectedListItem {
   background: linear-gradient(
     101.14deg,
     rgba(46, 103, 153, 0.41) 6.13%,

--- a/src/components/Events/EventAvailabilityDialogBody.vue
+++ b/src/components/Events/EventAvailabilityDialogBody.vue
@@ -1,0 +1,216 @@
+<template>
+  <v-container fluid>
+    <v-card class="rounded-lg mainBlur">
+      <v-card-title class="font-weight-bold text-darkBlue ml-4 mt-4">
+        <v-row>
+          <v-col class="text-h5 font-weight-bold pb-0 mb-2">
+            {{ eventData.title }} Availability</v-col
+          >
+        </v-row>
+      </v-card-title>
+      <v-card-subtitle class="font-weight-bold text-mediumBlue pt-0 ml-4">
+        {{ formatDate(eventData.date) }}
+      </v-card-subtitle>
+      <v-card-subtitle class="font-weight-bold text-mediumBlue ml-4">
+        {{ timesInfoString }}
+      </v-card-subtitle>
+      <v-card-text class="pb-0">
+        <v-container>
+          <v-row>
+            <v-col>
+              <v-row v-for="(availability, index) in availabilities">
+                <v-col cols="5">
+                  <v-text-field
+                    readonly
+                    type="time"
+                    placeholder="Start Time"
+                    v-model="availability.starttime"></v-text-field>
+                </v-col>
+                <v-col cols="5">
+                  <v-text-field
+                    readonly
+                    type="time"
+                    placeholder="End Time"
+                    v-model="availability.endtime"></v-text-field>
+                </v-col>
+                <v-col cols="2">
+                  <v-btn
+                    rounded="lg"
+                    class="mr-3 mainBlur buttonCancel text-none font-weight-bold"
+                    @click="removeAvailabilitySlot(index)">
+                    Delete
+                  </v-btn>
+                </v-col>
+              </v-row>
+              <!-- New -->
+              <v-row v-if="addNewAvailability">
+                <v-col cols="4">
+                  <v-text-field
+                    type="time"
+                    placeholder="Start Time"
+                    v-model="newAvailability.starttime"></v-text-field>
+                </v-col>
+                <v-col cols="4">
+                  <v-text-field
+                    type="time"
+                    placeholder="End Time"
+                    v-model="newAvailability.endtime"></v-text-field>
+                </v-col>
+                <v-col cols="2">
+                  <v-btn
+                    rounded="lg"
+                    class="mr-3 mainBlur buttonCancel text-none font-weight-bold"
+                    @click="cancelAddNewAvailabilitySlot()">
+                    Cancel
+                  </v-btn>
+                </v-col>
+                <v-col cols="2">
+                  <v-btn
+                    rounded="lg"
+                    class="mr-3 mainBlur buttonGradient text-white text-none font-weight-bold"
+                    @click="saveNewAvailabilitySlot()">
+                    Save
+                  </v-btn>
+                </v-col>
+              </v-row>
+            </v-col>
+          </v-row>
+
+          <v-row>
+            <v-col>
+              <v-btn
+                rounded="lg"
+                class="mainBlur buttonGradient text-white text-none font-weight-bold"
+                block
+                @click="addAvailabilitySlot()"
+                >Add Time</v-btn
+              >
+            </v-col>
+          </v-row>
+        </v-container>
+      </v-card-text>
+      <v-card-actions class="mr-2 mb-2 pt-4 pr-2">
+        <v-btn
+          rounded="lg"
+          elevation="0"
+          class="text-none buttonCancel ml-auto mr-3 text-white font-weight-bold"
+          @click="closeDialog()">
+          Cancel
+        </v-btn>
+        <v-btn
+          rounded="lg"
+          elevation="0"
+          class="text-none buttonGradient text-white font-weight-bold"
+          @click="createOrEditAvailabilities()">
+          {{ isEdit ? "Save Availabilities" : "Add Availabilities" }}
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-container>
+</template>
+
+<script>
+  import { useEventsStore } from "../../stores/EventsStore.js";
+  import { useUserStore } from "../../stores/UserStore.js";
+  import { mapStores } from "pinia";
+  import { DateTimeMixin } from "../../mixins/DateTimeMixin.js";
+
+  export default {
+    name: "EventAvailabilityDialogBody",
+    components: {},
+    data() {
+      return {
+        eventData: JSON.parse(JSON.stringify(this.sentEventData)),
+        isEdit: this.sentBool,
+        timeslots: JSON.parse(JSON.stringify(this.sentEventData)).timeslots,
+        timesInfoString: JSON.parse(JSON.stringify(this.sentEventData))
+          .timesInfoString,
+        availabilities: JSON.parse(JSON.stringify(this.sentAvailabilityData)),
+        newAvailabilities: [],
+        newAvailability: {},
+        removedAvailabilities: [],
+        addNewAvailability: false,
+      };
+    },
+    mixins: [DateTimeMixin],
+    props: {
+      sentEventData: {},
+      sentAvailabilityData: [],
+      sentBool: false,
+    },
+    computed: {
+      ...mapStores(useEventsStore, useUserStore),
+    },
+    watch: {
+      sentBool(newBool) {
+        this.isEdit = newBool;
+      },
+      sentEventData(data) {
+        this.eventData = JSON.parse(JSON.stringify(data));
+        this.timeslots = this.eventData.timeslots;
+        this.timesInfoString = this.eventData.timesInfoString;
+      },
+      sentAvailabilityData(data) {
+        this.availabilities = data;
+        this.editedAvailabilities = this.availabilities;
+      },
+    },
+    async mounted() {
+      if (!this.isEdit) {
+        this.addAvailabilitySlot();
+      }
+    },
+    methods: {
+      createOrEditAvailabilities() {
+        if (!this.isEdit) {
+          this.userStore.createAvailabilitiesForEvent(this.availabilities);
+        } else {
+          this.userStore.updateAvailabilitiesForEvent(
+            this.newAvailabilities,
+            this.removedAvailabilities
+          );
+        }
+        this.closeDialog();
+      },
+      closeDialog() {
+        this.$emit("closeEventDialogEvent");
+      },
+      addAvailabilitySlot() {
+        if (this.addNewAvailability) {
+          alert("Already adding new availability");
+        } else {
+          this.newAvailability = {
+            starttime: "",
+            endtime: "",
+            eventId: this.eventData.eventId,
+          };
+          this.addNewAvailability = true;
+        }
+      },
+      removeAvailabilitySlot(index) {
+        this.removedAvailabilities.push(this.availabilities[index]);
+        this.availabilities.splice(index, 1);
+      },
+      saveNewAvailabilitySlot() {
+        this.availabilities.push(this.newAvailability);
+        this.newAvailabilities.push(this.newAvailability);
+        this.newAvailability = {};
+        this.addNewAvailability = false;
+      },
+      cancelAddNewAvailabilitySlot() {
+        this.newAvailability = {};
+        this.addNewAvailability = false;
+      },
+    },
+  };
+</script>
+
+<style scoped>
+  /* Overwrites the opacity filter put on card subtitles */
+  .v-card-subtitle {
+    opacity: 100%;
+  }
+  .v-text-field {
+    border-radius: 100px;
+  }
+</style>

--- a/src/components/Events/EventComponent.vue
+++ b/src/components/Events/EventComponent.vue
@@ -1,11 +1,11 @@
 <template>
   <v-container fluid class="eventComponent">
     <v-card elevation="0" class="eventsGradient mainblur rounded-lg">
-      <v-card elevation="0" class="ma-3 rounded-lg lighterBlur">
+      <v-card elevation="0" class="ma-3 rounded-md lighterBlur">
         <v-card-title class="font-weight-bold text-h6 text-darkGray pb-0">
           <v-row>
             <v-col>
-              {{ eventData.type }}
+              {{ eventData.title }}
             </v-col>
             <v-col class="text-right">
               <!-- <v-btn

--- a/src/components/Events/EventRepertoireSelectionBody.vue
+++ b/src/components/Events/EventRepertoireSelectionBody.vue
@@ -29,8 +29,8 @@
                       @click="setSelectedPiece(piece)"
                       :class="
                         isCurrentlySelected(piece.pieceId)
-                          ? 'selectedSong'
-                          : 'unSelectedSong'
+                          ? 'selectedListItem'
+                          : 'unSelectedListItem'
                       "
                       :key="piece">
                       <v-card-text>

--- a/src/components/Events/EventSignupDialogBody.vue
+++ b/src/components/Events/EventSignupDialogBody.vue
@@ -308,8 +308,8 @@
       async selectedInstructor(instructor) {
         if (instructor) {
           this.selectedInstructorAvailability =
-            await this.eventsStore.getAvailaibilityForEventByInstructorId(
-              instructor.instructorId,
+            await this.eventsStore.getAvailaibilityForEventByUserId(
+              instructor.userId,
               this.eventData.eventId
             );
         }

--- a/src/components/Events/EventSignupDialogBody.vue
+++ b/src/components/Events/EventSignupDialogBody.vue
@@ -27,7 +27,7 @@
                   v-model="selectedInstructor"
                   :items="this.userStore.userRoleInfo.instructors"
                   item-title="name"
-                  item-value="id"
+                  item-value="instructorId"
                   return-object>
                 </v-select>
               </v-col>
@@ -40,7 +40,7 @@
                   v-model="selectedAccompanist"
                   :items="this.userStore.userRoleInfo.accompanists"
                   item-title="name"
-                  item-value="id"
+                  item-value="accompanistId"
                   return-object>
                 </v-select>
               </v-col>
@@ -144,35 +144,74 @@
               Timeslot Selection
             </v-card-subtitle>
             <v-row class="pt-3">
-              <v-card-text v-for="slotsList in timeslots">
-                <v-btn
-                  v-for="timeSlot in slotsList"
-                  @click="setSelectedTimeslot(timeSlot)"
-                  :class="
-                    selectedTimeslot.id === timeSlot.id
-                      ? 'bg-darkGray'
-                      : 'buttonGradient'
-                  "
-                  elevation="0"
-                  rounded="lg"
-                  size="x-small"
-                  class="text-white font-weight-bold mr-2"
-                  >{{
-                    parseInt(timeSlot.time.substring(0, 2)) > 12
-                      ? parseInt(timeSlot.time.substring(0, 2)) -
-                        12 +
-                        timeSlot.time.substring(2, timeSlot.time.length - 3)
-                      : parseInt(timeSlot.time.substring(0, 2)) < 10
-                      ? timeSlot.time.substring(1, timeSlot.time.length - 3)
-                      : timeSlot.time.substring(0, timeSlot.time.length - 3)
-                  }}</v-btn
-                >
-              </v-card-text>
+              <v-col>
+                <v-sheet
+                  class="overflow-y-auto"
+                  max-height="35vh"
+                  min-height="35vh">
+                  <v-row v-for="slotsList in timeslots" class="pb-4">
+                    <v-col>
+                      <v-row
+                        v-for="timeSlot in slotsList"
+                        class="mx-0 px-0 pb-2 my-0">
+                        <v-col class="pa-0 mx-0">
+                          <v-card
+                            flat
+                            class="rounded-lg my-0 py-0"
+                            v-if="isTimeslotAvailableForInstructor(timeSlot)"
+                            :class="
+                              selectedTimeslot.id === timeSlot.id
+                                ? 'selectedListItem'
+                                : 'unSelectedListItem'
+                            "
+                            @click="setSelectedTimeslot(timeSlot)"
+                            :key="timeSlot">
+                            <v-row class="py-2">
+                              <v-col class="">
+                                <v-card-subtitle
+                                  class="font-weight-bold"
+                                  :class="
+                                    selectedTimeslot.id === timeSlot.id
+                                      ? 'text-white'
+                                      : 'text-darkGray'
+                                  ">
+                                  {{
+                                    parseInt(timeSlot.time.substring(0, 2)) > 12
+                                      ? parseInt(
+                                          timeSlot.time.substring(0, 2)
+                                        ) -
+                                        12 +
+                                        timeSlot.time.substring(
+                                          2,
+                                          timeSlot.time.length - 3
+                                        )
+                                      : parseInt(
+                                          timeSlot.time.substring(0, 2)
+                                        ) < 10
+                                      ? timeSlot.time.substring(
+                                          1,
+                                          timeSlot.time.length - 3
+                                        )
+                                      : timeSlot.time.substring(
+                                          0,
+                                          timeSlot.time.length - 3
+                                        )
+                                  }}
+                                </v-card-subtitle>
+                              </v-col>
+                            </v-row>
+                          </v-card>
+                        </v-col>
+                      </v-row>
+                    </v-col>
+                  </v-row>
+                </v-sheet>
+              </v-col>
             </v-row>
           </v-col>
         </v-row>
       </v-card-text>
-      <v-card-actions class="mr-2 mb-2 pt-0 pr-4">
+      <v-card-actions class="mr-2 mb-2 pt-4 pr-2">
         <v-btn
           rounded="lg"
           elevation="0"
@@ -227,7 +266,10 @@
         selectedEventSongs: JSON.parse(JSON.stringify(this.sentSignupData))
           .songs,
         selectedInstructor: {},
+        selectedInstructorAvailability: [],
+        instructorAvailabilityTimeslots: [],
         selectedAccompanist: {},
+        selectedAccompanistAvailability: [],
         eventRepertoireSelection: false,
       };
     },
@@ -263,6 +305,18 @@
         this.timeslots = this.eventData.timeslots;
         this.timesInfoString = this.eventData.timesInfoString;
       },
+      async selectedInstructor(instructor) {
+        if (instructor) {
+          this.selectedInstructorAvailability =
+            await this.eventsStore.getAvailaibilityForEventByInstructorId(
+              instructor.instructorId,
+              this.eventData.eventId
+            );
+          console.log(this.selectedInstructorAvailability);
+        }
+
+        this.generateFilteredTimeslotList();
+      },
     },
     mounted() {
       // Set default selected piece
@@ -278,6 +332,39 @@
       }
     },
     methods: {
+      generateFilteredTimeslotList() {
+        let interval = this.eventData.times[0].interval;
+        let times = [];
+        console.log(this.selectedInstructorAvailability);
+        for (let time of this.selectedInstructorAvailability) {
+          let obj = {
+            startTime: new Date(time.eventDate + " " + time.startTime),
+            endTime: new Date(time.eventDate + " " + time.endTime),
+            interval: interval,
+          };
+          times.push(obj);
+        }
+
+        console.log(times);
+
+        this.instructorAvailabilityTimeslots = this.getTimeSlotsCombined(times);
+        console.log(this.instructorAvailabilityTimeslots);
+      },
+      isTimeslotAvailableForInstructor(timeslot) {
+        console.log(timeslot);
+        console.log(this.instructorAvailabilityTimeslots);
+        if (this.instructorAvailabilityTimeslots.length > 0) {
+          let isAvailable = false;
+          this.instructorAvailabilityTimeslots.find(
+            (ts) => ts.time === timeslot.time
+          )
+            ? (isAvailable = true)
+            : (isAvailable = false);
+          console.log(isAvailable);
+          return isAvailable;
+        }
+        return true;
+      },
       setOrAddSelectedPieces(pieces) {
         this.selectedPieces = pieces;
         this.eventRepertoireSelection = false;

--- a/src/components/Events/EventSignupDialogBody.vue
+++ b/src/components/Events/EventSignupDialogBody.vue
@@ -312,7 +312,6 @@
               instructor.instructorId,
               this.eventData.eventId
             );
-          console.log(this.selectedInstructorAvailability);
         }
 
         this.generateFilteredTimeslotList();
@@ -335,7 +334,6 @@
       generateFilteredTimeslotList() {
         let interval = this.eventData.times[0].interval;
         let times = [];
-        console.log(this.selectedInstructorAvailability);
         for (let time of this.selectedInstructorAvailability) {
           let obj = {
             startTime: new Date(time.eventDate + " " + time.startTime),
@@ -345,14 +343,9 @@
           times.push(obj);
         }
 
-        console.log(times);
-
         this.instructorAvailabilityTimeslots = this.getTimeSlotsCombined(times);
-        console.log(this.instructorAvailabilityTimeslots);
       },
       isTimeslotAvailableForInstructor(timeslot) {
-        console.log(timeslot);
-        console.log(this.instructorAvailabilityTimeslots);
         if (this.instructorAvailabilityTimeslots.length > 0) {
           let isAvailable = false;
           this.instructorAvailabilityTimeslots.find(
@@ -360,7 +353,6 @@
           )
             ? (isAvailable = true)
             : (isAvailable = false);
-          console.log(isAvailable);
           return isAvailable;
         }
         return true;

--- a/src/components/Events/EventSignupItem.vue
+++ b/src/components/Events/EventSignupItem.vue
@@ -4,7 +4,7 @@
       <v-row class="pa-4" no-gutters align="center">
         <v-col cols="auto">
           <v-card-title class="font-weight-bold text-white pb-0 pt-0 pl-0">
-            {{ eventData.type }}
+            {{ eventData.title }}
           </v-card-title>
           <v-card-subtitle class="font-weight-semi-bold text-darkBlue pl-0">
             {{ formatDate(eventData.date) }}

--- a/src/mixins/DateTimeMixin.js
+++ b/src/mixins/DateTimeMixin.js
@@ -30,11 +30,14 @@ export const DateTimeMixin = {
       let totalSlots = [];
 
       for (let time of times) {
+        console.log(time);
         let slots = [];
         let intervalMillis = time.interval * 60 * 1000;
 
         let startTime = new Date(time.startTime);
         let endTime = new Date(time.endTime);
+
+        console.log(startTime);
 
         while (startTime < endTime) {
           let mins = (startTime.getMinutes() + "0").slice(0, 2);
@@ -52,6 +55,38 @@ export const DateTimeMixin = {
         }
 
         totalSlots.push(slots);
+      }
+
+      return totalSlots;
+    },
+
+    getTimeSlotsCombined(times) {
+      let counter = 1;
+      let totalSlots = [];
+
+      for (let time of times) {
+        console.log(time);
+        let intervalMillis = time.interval * 60 * 1000;
+
+        let startTime = new Date(time.startTime);
+        let endTime = new Date(time.endTime);
+
+        console.log(startTime);
+
+        while (startTime < endTime) {
+          let mins = (startTime.getMinutes() + "0").slice(0, 2);
+          totalSlots.push({
+            id: counter,
+            time:
+              (startTime.getHours() < 10 ? "0" : "") +
+              startTime.getHours() +
+              ":" +
+              mins +
+              ":00",
+          });
+          startTime.setTime(startTime.getTime() + intervalMillis);
+          counter++;
+        }
       }
 
       return totalSlots;

--- a/src/mixins/DateTimeMixin.js
+++ b/src/mixins/DateTimeMixin.js
@@ -65,13 +65,10 @@ export const DateTimeMixin = {
       let totalSlots = [];
 
       for (let time of times) {
-        console.log(time);
         let intervalMillis = time.interval * 60 * 1000;
 
         let startTime = new Date(time.startTime);
         let endTime = new Date(time.endTime);
-
-        console.log(startTime);
 
         while (startTime < endTime) {
           let mins = (startTime.getMinutes() + "0").slice(0, 2);

--- a/src/services/availability.js
+++ b/src/services/availability.js
@@ -9,6 +9,11 @@ class AvailabilityDataService {
   getAll() {
     return http.get("/performance-t3/availability");
   }
+  getInstructorAndEvent(instructorId, eventId) {
+    return http.get(
+      `/performance-t3/availability/getByInstructorAndEvent/${instructorId}/${eventId}`
+    );
+  }
   getStartDate(id) {
     return http.get(`/performance-t3/availability/startdate/${id}`);
   }

--- a/src/services/availability.js
+++ b/src/services/availability.js
@@ -9,9 +9,9 @@ class AvailabilityDataService {
   getAll() {
     return http.get("/performance-t3/availability");
   }
-  getInstructorAndEvent(instructorId, eventId) {
+  getUserAndEvent(userId, eventId) {
     return http.get(
-      `/performance-t3/availability/getByInstructorAndEvent/${instructorId}/${eventId}`
+      `/performance-t3/availability/getByUserAndEvent/${userId}/${eventId}`
     );
   }
   getStartDate(id) {

--- a/src/services/instructors.js
+++ b/src/services/instructors.js
@@ -9,6 +9,9 @@ class InstructorsDataService {
   getAll() {
     return http.get("/performance-t3/instructors");
   }
+  getAllInfo(id) {
+    return http.get(`/performance-t3/instructors/allInfo/${id}`);
+  }
   getSingle(id) {
     return http.get(`/performance-t3/instructors/userid/${id}`);
   }

--- a/src/stores/EventsStore.js
+++ b/src/stores/EventsStore.js
@@ -219,9 +219,9 @@ export const useEventsStore = defineStore("events", {
       // Update the EventsStore.events with the new data
       this.events.push({ ...eventData, ...{ times: finalTimeData } });
     },
-    async getAvailaibilityForEventByInstructorId(instructorId, eventId) {
+    async getAvailaibilityForEventByUserId(userId, eventId) {
       let list = [];
-      await AvailabilityDataService.getInstructorAndEvent(instructorId, eventId)
+      await AvailabilityDataService.getUserAndEvent(userId, eventId)
         .then((response) => {
           list = response.data.Availability;
 

--- a/src/stores/EventsStore.js
+++ b/src/stores/EventsStore.js
@@ -3,8 +3,7 @@ import EventTimeDataService from "../services/eventtime.js";
 import EventDataService from "../services/event.js";
 import EventSignUpDataService from "../services/eventsignup.js";
 import EventSongsDataService from "../services/eventsongs.js";
-import PiecesDataService from "../services/pieces.js";
-import ComposersDataService from "../services/composers.js";
+import AvailabilityDataService from "../services/availability.js";
 import { useUserStore } from "../stores/UserStore.js";
 import { DateTimeMixin } from "../mixins/DateTimeMixin.js";
 
@@ -24,6 +23,7 @@ export const useEventsStore = defineStore("events", {
         .then((response) => {
           this.events = response.data;
           this.createTimesAndDates();
+          console.log(this.events[0]);
         })
         .catch((e) => {
           console.log(e);
@@ -33,6 +33,7 @@ export const useEventsStore = defineStore("events", {
     async createTimesAndDates() {
       let timesFinal = [];
       for (let [i, event] of this.events.entries()) {
+        console.log(event.date);
         for (let [j, time] of event.times.entries()) {
           this.events[i].times[j] = {
             startTime: new Date(event.date + " " + time.starttime),
@@ -215,6 +216,33 @@ export const useEventsStore = defineStore("events", {
 
       // Update the EventsStore.events with the new data
       this.events.push({ ...eventData, ...{ times: finalTimeData } });
+    },
+    async getAvailaibilityForEventByInstructorId(instructorId, eventId) {
+      let list = [];
+      await AvailabilityDataService.getInstructorAndEvent(instructorId, eventId)
+        .then((response) => {
+          console.log(response.data);
+          console.log(response.data.Availability);
+          list = response.data.Availability;
+
+          for (let [i, item] of list.entries()) {
+            let dateObj = item.event.eventDate;
+            console.log(dateObj);
+            list[i] = {
+              ...item,
+              ...{ eventDate: dateObj },
+            };
+
+            delete item.event;
+          }
+
+          console.log(list);
+        })
+        .catch((e) => {
+          console.log(e);
+        });
+
+      return list;
     },
   },
 });

--- a/src/stores/EventsStore.js
+++ b/src/stores/EventsStore.js
@@ -221,13 +221,10 @@ export const useEventsStore = defineStore("events", {
       let list = [];
       await AvailabilityDataService.getInstructorAndEvent(instructorId, eventId)
         .then((response) => {
-          console.log(response.data);
-          console.log(response.data.Availability);
           list = response.data.Availability;
 
           for (let [i, item] of list.entries()) {
             let dateObj = item.event.eventDate;
-            console.log(dateObj);
             list[i] = {
               ...item,
               ...{ eventDate: dateObj },
@@ -235,8 +232,6 @@ export const useEventsStore = defineStore("events", {
 
             delete item.event;
           }
-
-          console.log(list);
         })
         .catch((e) => {
           console.log(e);


### PR DESCRIPTION
Adds the ability for an instructor to add their availability, and for a student to filter timeslots on a signup by their instructor's availability.

Backend PR for this as well.

**NEW** Instructor UserStore getAll:
New instructor userRoleInfo object looks as follows:
```
{
  "instructorId": 2,
  "title": "Private Instructor",
  "createdAt": "2023-04-05T11:06:02.000Z",
  "updatedAt": "2023-04-05T11:06:02.000Z",
  "availabilities": [
    {
      "availabilityId": 9,
      "eventId": 2,
      "starttime": "09:00:00",
      "endtime": "10:00:00"
    },
    {
      "availabilityId": 11,
      "eventId": 2,
      "starttime": "13:00:00",
      "endtime": "14:30:00"
    }
  ],
  "students": [
    {
      "studentId": 1,
      "level": 3,
      "major": "Vocal Music",
      "classification": "Senior",
      "semesters": 8,
      "userId": 1,
      "studentInstructorId": 1
    }
  ]
}
```